### PR TITLE
Refactor drive control and gyro reset functionality

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -95,7 +95,7 @@ public class RobotContainer {
                     -MathUtil.applyDeadband(
                         m_driverController.getX(), OIConstants.kDriveDeadband),
                     -MathUtil.applyDeadband(
-                        m_driverController.getThrottle(), OIConstants.kDriveDeadband),
+                        m_driverController.getZ(), OIConstants.kDriveDeadband),
                     true),
             m_robotDrive));
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -153,6 +153,17 @@ public class RobotContainer {
     midSpeedButton.onTrue(new InstantCommand(() -> m_robotDrive.setDriveSpeed(0.5)));
     lowSpeedButton.onTrue(new InstantCommand(() -> m_robotDrive.setDriveSpeed(0.25)));
 
+        // Bind buttons 5, 6, 7, and 8 to reset the gyro
+        new JoystickButton(m_driverController, 5)
+            .onTrue(new InstantCommand(m_robotDrive::resetGyro, m_robotDrive));
+        new JoystickButton(m_driverController, 6)
+            .onTrue(new InstantCommand(m_robotDrive::resetGyro, m_robotDrive));
+        new JoystickButton(m_driverController, 7)
+            .onTrue(new InstantCommand(m_robotDrive::resetGyro, m_robotDrive));
+        new JoystickButton(m_driverController, 8)
+            .onTrue(new InstantCommand(m_robotDrive::resetGyro, m_robotDrive));
+
+
 
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -41,6 +41,9 @@ import frc.robot.subsystems.CoralSubsystem.Setpoint;
 import frc.robot.subsystems.DriveSubsystem;
 import java.util.List;
 
+import edu.wpi.first.wpilibj.ADIS16470_IMU;
+import edu.wpi.first.wpilibj.ADIS16470_IMU.IMUAxis;
+
 /*
  * This class is where the bulk of the robot should be declared.  Since Command-based is a
  * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -41,8 +41,6 @@ import frc.robot.subsystems.CoralSubsystem.Setpoint;
 import frc.robot.subsystems.DriveSubsystem;
 import java.util.List;
 
-import edu.wpi.first.wpilibj.ADIS16470_IMU;
-import edu.wpi.first.wpilibj.ADIS16470_IMU.IMUAxis;
 
 /*
  * This class is where the bulk of the robot should be declared.  Since Command-based is a

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -94,7 +94,7 @@ public class RobotContainer {
                     -MathUtil.applyDeadband(
                         m_driverController.getX(), OIConstants.kDriveDeadband),
                     -MathUtil.applyDeadband(
-                        m_driverController.getZ(), OIConstants.kDriveDeadband),
+                        m_driverController.getThrottle(), OIConstants.kDriveDeadband),
                     true),
             m_robotDrive));
 

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -68,7 +68,7 @@ public class DriveSubsystem extends SubsystemBase {
   private double rotDelivered; 
 
   //Speed Control variables
-  public double currentDriveSpeed;
+  public double currentDriveSpeed = 0.75;
 
 
 

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -28,6 +28,7 @@ import edu.wpi.first.wpilibj.ADIS16470_IMU;
 import edu.wpi.first.wpilibj.ADIS16470_IMU.IMUAxis;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
@@ -263,10 +264,6 @@ public class DriveSubsystem extends SubsystemBase {
     m_rearRight.resetEncoders();
   }
 
-  /** Zeroes the heading of the robot. */
-  public Command zeroHeadingCommand() {
-    return this.runOnce(() -> m_gyro.reset());
-  }
 
   /**
    * Returns the heading of the robot.

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -68,7 +68,7 @@ public class DriveSubsystem extends SubsystemBase {
   private double rotDelivered; 
 
   //Speed Control variables
-  public double currentDriveSpeed = 0.75;
+  public double currentDriveSpeed = 0.5;
 
 
 

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -282,4 +282,8 @@ public class DriveSubsystem extends SubsystemBase {
   public double getTurnRate() {
     return m_gyro.getRate(IMUAxis.kZ) * (DriveConstants.kGyroReversed ? -1.0 : 1.0);
   }
+
+  public void resetGyro() {
+    m_gyro.setGyroAngle(IMUAxis.kZ, 0);
+  }
 }


### PR DESCRIPTION
Improve drive control by setting the initial speed and reintroducing twist control. Add functionality to reset the gyro using multiple buttons and adjust the IMU's Z angle. Remove non-functional field reset function.